### PR TITLE
Linter & Compatibility

### DIFF
--- a/Graph_Sampling/ForestFire.py
+++ b/Graph_Sampling/ForestFire.py
@@ -1,7 +1,8 @@
 import random
 import networkx as nx
-import matplotlib.pyplot as plt
-import time
+# import matplotlib.pyplot as plt
+# import time
+
 
 # G : Original Graph
 # size : size of the sampled graph
@@ -9,39 +10,35 @@ class ForestFire():
     def __init__(self):
         self.G1 = nx.Graph()
 
-    def forestfire(self,G,size):
-        list_nodes=list(G.nodes())
-        #print(len(G))
+    def forestfire(self, G, size):
+        list_nodes = list(G.nodes())
+        # print(len(G))
         dictt = set()
-        random_node = random.sample(set(list_nodes),1)[0]
-        #print(random_node)
-        q = set() #q = set contains the distinct values
+        random_node = random.sample(set(list_nodes), 1)[0]
+        # print(random_node)
+        q = set()   # q = set contains the distinct values
         q.add(random_node)
-        while(len(self.G1.nodes())<size):
-            if(len(q)>0):
+        while(len(self.G1.nodes()) < size):
+            if(len(q) > 0):
                 initial_node = q.pop()
                 if(initial_node not in dictt):
-                    #print(initial_node)
+                    # print(initial_node)
                     dictt.add(initial_node)
                     neighbours = list(G.neighbors(initial_node))
-                    #print(list(G.neighbors(initial_node)))
-                    np = random.randint(1,len(neighbours))
-                    #print(np)
-                    #print(neighbours[:np])
+                    # print(list(G.neighbors(initial_node)))
+                    np = random.randint(1, len(neighbours))
+                    # print(np)
+                    # print(neighbours[:np])
                     for x in neighbours[:np]:
-                        if(len(self.G1.nodes())<size):
-                            self.G1.add_edge(initial_node,x)
+                        if(len(self.G1.nodes()) < size):
+                            self.G1.add_edge(initial_node, x)
                             q.add(x)
                         else:
                             break
                 else:
                     continue
             else:
-                random_node = random.sample(set(list_nodes) and dictt,1)[0]
+                random_node = random.sample(set(list_nodes) and dictt, 1)[0]
                 q.add(random_node)
         q.clear()
         return self.G1
-
-
-
-

--- a/Graph_Sampling/MHRW.py
+++ b/Graph_Sampling/MHRW.py
@@ -1,13 +1,14 @@
 import random
-import time
+# import time
 import networkx as nx
-import matplotlib.pyplot as plt
+# import matplotlib.pyplot as plt
+
 
 class MHRW():
     def __init__(self):
         self.G1 = nx.Graph()
 
-    def mhrw(self,G,node,size):
+    def mhrw(self, G, node, size):
         dictt = {}
         node_list = set()
         node_list.add(node)
@@ -20,13 +21,13 @@ class MHRW():
         while(len(self.G1.nodes()) < size):
             if(len(node_list) > 0):
                 child_node = node_list.pop()
-                p =  round(random.uniform(0,1),4)
+                p = round(random.uniform(0, 1), 4)
                 if(child_node not in dictt):
                     related_listt = list(G.neighbors(child_node))
                     degree_c = G.degree(child_node)
                     dictt[child_node] = child_node
-                    if(p <= min(1,degree_p/degree_c) and child_node in list(G.neighbors(parent_node))):
-                        self.G1.add_edge(parent_node,child_node)
+                    if(p <= min(1, degree_p / degree_c) and child_node in list(G.neighbors(parent_node))):
+                        self.G1.add_edge(parent_node, child_node)
                         parent_node = child_node
                         degree_p = degree_c
                         node_list.clear()
@@ -34,19 +35,18 @@ class MHRW():
                     else:
                         del dictt[child_node]
 
-
-            # node_list set becomes empty or size is not reached 
+            # node_list set becomes empty or size is not reached
             # insert some random nodes into the set for next processing
             else:
-                node_list.update(random.sample(set(G.nodes())-set(self.G1.nodes()),3))
+                node_list.update(random.sample(set(G.nodes()) - set(self.G1.nodes()), 3))
                 parent_node = node_list.pop()
                 G.add_node(parent_node)
                 related_list = list(G.neighbors(parent_node))
                 node_list.clear()
                 node_list.update(related_list)
         return self.G1
-    
-    def induced_mhrw(self,G,size,node):
-        sampled_graph = mhrw(self.G1,G,size,node)
+
+    def induced_mhrw(self, G, size, node):
+        sampled_graph = mhrw(self.G1, G, size, node)
         induced_graph = G.subgraph(sampled_graph.nodes())
         return induced_graph

--- a/Graph_Sampling/SRW_RWF_ISRW.py
+++ b/Graph_Sampling/SRW_RWF_ISRW.py
@@ -1,23 +1,24 @@
 import random
-import time
-import datetime
-import io
-import array,re,itertools
+# import time
+# import datetime
+# import io
+# import array, re, itertools
 import numpy as np
 import networkx as nx
-import matplotlib.pyplot as plt
-from itertools import groupby
+# import matplotlib.pyplot as plt
+# from itertools import groupby
+
 
 class SRW_RWF_ISRW:
 
     def __init__(self):
         self.growth_size = 2
-        self.T = 100 #number of iterations
-        #with a probability (1-fly_back_prob) select a neighbor node
-        #with a probability fly_back_prob go back to the initial vertex
+        self.T = 100    # number of iterations
+        # with a probability (1-fly_back_prob) select a neighbor node
+        # with a probability fly_back_prob go back to the initial vertex
         self.fly_back_prob = 0.15
 
-    def random_walk_sampling_simple(self,complete_graph, nodes_to_sample):
+    def random_walk_sampling_simple(self, complete_graph, nodes_to_sample):
         complete_graph = nx.convert_node_labels_to_integers(complete_graph, 0, 'default', True)
         # giving unique id to every node same as built-in function id
         for n, data in complete_graph.nodes(data=True):
@@ -25,7 +26,7 @@ class SRW_RWF_ISRW:
 
         nr_nodes = len(complete_graph.nodes())
         upper_bound_nr_nodes_to_sample = nodes_to_sample
-        index_of_first_random_node = random.randint(0, nr_nodes-1)
+        index_of_first_random_node = random.randint(0, nr_nodes - 1)
         sampled_graph = nx.Graph()
 
         sampled_graph.add_node(complete_graph.node[index_of_first_random_node]['id'])
@@ -40,15 +41,15 @@ class SRW_RWF_ISRW:
             sampled_graph.add_node(chosen_node)
             sampled_graph.add_edge(curr_node, chosen_node)
             curr_node = chosen_node
-            iteration = iteration+1
+            iteration = iteration + 1
 
             if iteration % self.T == 0:
                 if ((sampled_graph.number_of_edges() - edges_before_t_iter) < self.growth_size):
-                    curr_node = random.randint(0, nr_nodes-1)
+                    curr_node = random.randint(0, nr_nodes - 1)
                 edges_before_t_iter = sampled_graph.number_of_edges()
         return sampled_graph
 
-    def random_walk_sampling_with_fly_back(self,complete_graph, nodes_to_sample, fly_back_prob):
+    def random_walk_sampling_with_fly_back(self, complete_graph, nodes_to_sample, fly_back_prob):
         complete_graph = nx.convert_node_labels_to_integers(complete_graph, 0, 'default', True)
         # giving unique id to every node same as built-in function id
         for n, data in complete_graph.nodes(data=True):
@@ -57,7 +58,7 @@ class SRW_RWF_ISRW:
         nr_nodes = len(complete_graph.nodes())
         upper_bound_nr_nodes_to_sample = nodes_to_sample
 
-        index_of_first_random_node = random.randint(0, nr_nodes-1)
+        index_of_first_random_node = random.randint(0, nr_nodes - 1)
         sampled_graph = nx.Graph()
 
         sampled_graph.add_node(complete_graph.node[index_of_first_random_node]['id'])
@@ -71,15 +72,15 @@ class SRW_RWF_ISRW:
             chosen_node = edges[index_of_edge]
             sampled_graph.add_node(chosen_node)
             sampled_graph.add_edge(curr_node, chosen_node)
-            choice = np.random.choice(['prev','neigh'], 1, p=[fly_back_prob,1-fly_back_prob])
+            choice = np.random.choice(['prev', 'neigh'], 1, p=[fly_back_prob, 1 - fly_back_prob])
             if choice == 'neigh':
                 curr_node = chosen_node
-            iteration=iteration+1
+            iteration = iteration + 1
 
             if iteration % self.T == 0:
                 if ((sampled_graph.number_of_edges() - edges_before_t_iter) < self.growth_size):
-                    curr_node = random.randint(0, nr_nodes-1)
-                    print ("Choosing another random node to continue random walk ")
+                    curr_node = random.randint(0, nr_nodes - 1)
+                    print("Choosing another random node to continue random walk ")
                 edges_before_t_iter = sampled_graph.number_of_edges()
 
         return sampled_graph
@@ -89,7 +90,7 @@ class SRW_RWF_ISRW:
         # giving unique id to every node same as built-in function id
         for n, data in complete_graph.nodes(data=True):
             complete_graph.node[n]['id'] = n
-            
+
         nr_nodes = len(complete_graph.nodes())
         upper_bound_nr_nodes_to_sample = nodes_to_sample
         index_of_first_random_node = random.randint(0, nr_nodes - 1)
@@ -105,7 +106,7 @@ class SRW_RWF_ISRW:
             chosen_node = edges[index_of_edge]
             Sampled_nodes.add(complete_graph.node[chosen_node]['id'])
             curr_node = chosen_node
-            iteration=iteration+1
+            iteration = iteration + 1
 
             if iteration % self.T == 0:
                 if ((len(Sampled_nodes) - nodes_before_t_iter) < self.growth_size):

--- a/Graph_Sampling/SRW_RWF_ISRW.py
+++ b/Graph_Sampling/SRW_RWF_ISRW.py
@@ -22,14 +22,14 @@ class SRW_RWF_ISRW:
         complete_graph = nx.convert_node_labels_to_integers(complete_graph, 0, 'default', True)
         # giving unique id to every node same as built-in function id
         for n, data in complete_graph.nodes(data=True):
-            complete_graph.node[n]['id'] = n
+            complete_graph.nodes[n]['id'] = n
 
         nr_nodes = len(complete_graph.nodes())
         upper_bound_nr_nodes_to_sample = nodes_to_sample
         index_of_first_random_node = random.randint(0, nr_nodes - 1)
         sampled_graph = nx.Graph()
 
-        sampled_graph.add_node(complete_graph.node[index_of_first_random_node]['id'])
+        sampled_graph.add_node(complete_graph.nodes[index_of_first_random_node]['id'])
 
         iteration = 1
         edges_before_t_iter = 0
@@ -53,7 +53,7 @@ class SRW_RWF_ISRW:
         complete_graph = nx.convert_node_labels_to_integers(complete_graph, 0, 'default', True)
         # giving unique id to every node same as built-in function id
         for n, data in complete_graph.nodes(data=True):
-            complete_graph.node[n]['id'] = n
+            complete_graph.nodes[n]['id'] = n
 
         nr_nodes = len(complete_graph.nodes())
         upper_bound_nr_nodes_to_sample = nodes_to_sample
@@ -61,7 +61,7 @@ class SRW_RWF_ISRW:
         index_of_first_random_node = random.randint(0, nr_nodes - 1)
         sampled_graph = nx.Graph()
 
-        sampled_graph.add_node(complete_graph.node[index_of_first_random_node]['id'])
+        sampled_graph.add_node(complete_graph.nodes[index_of_first_random_node]['id'])
 
         iteration = 1
         edges_before_t_iter = 0
@@ -89,13 +89,13 @@ class SRW_RWF_ISRW:
         complete_graph = nx.convert_node_labels_to_integers(complete_graph, 0, 'default', True)
         # giving unique id to every node same as built-in function id
         for n, data in complete_graph.nodes(data=True):
-            complete_graph.node[n]['id'] = n
+            complete_graph.nodes[n]['id'] = n
 
         nr_nodes = len(complete_graph.nodes())
         upper_bound_nr_nodes_to_sample = nodes_to_sample
         index_of_first_random_node = random.randint(0, nr_nodes - 1)
 
-        Sampled_nodes = set([complete_graph.node[index_of_first_random_node]['id']])
+        Sampled_nodes = set([complete_graph.nodes[index_of_first_random_node]['id']])
 
         iteration = 1
         nodes_before_t_iter = 0
@@ -104,7 +104,7 @@ class SRW_RWF_ISRW:
             edges = [n for n in complete_graph.neighbors(curr_node)]
             index_of_edge = random.randint(0, len(edges) - 1)
             chosen_node = edges[index_of_edge]
-            Sampled_nodes.add(complete_graph.node[chosen_node]['id'])
+            Sampled_nodes.add(complete_graph.nodes[chosen_node]['id'])
             curr_node = chosen_node
             iteration = iteration + 1
 

--- a/Graph_Sampling/Snowball.py
+++ b/Graph_Sampling/Snowball.py
@@ -1,57 +1,58 @@
-import json
-import sys
+# import json
+# import sys
 import random
-import math 
-import time
+# import math
+# import time
 import networkx as nx
-import matplotlib.pyplot as plt
-from collections import defaultdict
+# import matplotlib.pyplot as plt
+# from collections import defaultdict
 
 
 class Queue():
-    #Constructor creates a list
+    # Constructor creates a list
     def __init__(self):
         self.queue = list()
-    
-    #Adding elements to queue
-    def enqueue(self,data):
-        #Checking to avoid duplicate entry (not mandatory)
+
+    # Adding elements to queue
+    def enqueue(self, data):
+        # Checking to avoid duplicate entry (not mandatory)
         if data not in self.queue:
-            self.queue.insert(0,data)
+            self.queue.insert(0, data)
             return True
         return False
-    
-    #Removing the last element from the queue
+
+    # Removing the last element from the queue
     def dequeue(self):
-        if len(self.queue)>0:
+        if len(self.queue) > 0:
             return self.queue.pop()
         else:
-            #plt.show()
+            # plt.show()
             exit()
-    
-    #Getting the size of the queue
+
+    # Getting the size of the queue
     def size(self):
         return len(self.queue)
-    
-    #printing the elements of the queue
+
+    # printing the elements of the queue
     def printQueue(self):
         return self.queue
+
 
 class Snowball():
 
     def __init__(self):
         self.G1 = nx.Graph()
 
-    def snowball(self,G,size,k):
-        q=Queue() 
-        list_nodes=list(G.nodes())
+    def snowball(self, G, size, k):
+        q = Queue()
+        list_nodes = list(G.nodes())
         m = k
         dictt = set()
         while(m):
-            id = random.sample(list(G.nodes()),1)[0]
+            id = random.sample(list(G.nodes()), 1)[0]
             q.enqueue(id)
             m = m - 1
-        #print(q.printQueue())
+        # print(q.printQueue())
         while(len(self.G1.nodes()) <= size):
             if(q.size() > 0):
                 id = q.dequeue()
@@ -62,18 +63,16 @@ class Snowball():
                     if(len(list_neighbors) > k):
                         for x in list_neighbors[:k]:
                             q.enqueue(x)
-                            self.G1.add_edge(id,x)
+                            self.G1.add_edge(id, x)
                     elif(len(list_neighbors) <= k and len(list_neighbors) > 0):
                         for x in list_neighbors:
                             q.enqueue(x)
-                            self.G1.add_edge(id,x)
+                            self.G1.add_edge(id, x)
                 else:
                     continue
             else:
-                initial_nodes = random.sample(list(G.nodes()) and list(dictt),k)
+                initial_nodes = random.sample(list(G.nodes()) and list(dictt), k)
                 no_of_nodes = len(initial_nodes)
                 for id in initial_nodes:
-                    q.enqueue(id) 
+                    q.enqueue(id)
         return self.G1
-
-

--- a/Graph_Sampling/TIES.py
+++ b/Graph_Sampling/TIES.py
@@ -1,40 +1,40 @@
 import random
 import networkx as nx
-import matplotlib.pyplot as plt
+# import matplotlib.pyplot as plt
 import math
-import time
-import csv
-from datetime import datetime
+# import time
+# import csv
+# from datetime import datetime
+
 
 class TIES():
     def __init__(self):
         self.G1 = nx.Graph()
 
-    def ties(self,G,size,phi):
-        V = G.nodes()																	
-        #Calculate number of nodes in Graph G
-        Vs = []																			
-        #Empty list Vs														
+    def ties(self, G, size, phi):
+        V = G.nodes()
+        # Calculate number of nodes in Graph G
+        Vs = []
+        # Empty list Vs
         phi = round((phi * 0.01), 2)
-        while (len(Vs)) <= math.floor(phi * len(V)):									
-        #Loops run till sample size * length of V where V is number of nodes in graph as calculated above.
-            edges_sample = random.sample(G.edges(), 1)									
-            #Randomly samples one edge from a graph at a time
-            for a1, a2 in edges_sample:													
-            #Nodes corresponding to sample edge are retrieved and added in Graph G1
+        while (len(Vs)) <= math.floor(phi * len(V)):
+        # Loops run till sample size * length of V where V is number of nodes in graph as calculated above.
+            edges_sample = random.sample(G.edges(), 1)
+            # Randomly samples one edge from a graph at a time
+            for a1, a2 in edges_sample:
+            # Nodes corresponding to sample edge are retrieved and added in Graph G1
                 self.G1.add_edge(a1, a2)
                 if (a1 not in Vs):
                     Vs.append(a1)
                 if (a2 not in Vs):
-                    Vs.append(a2)															
-        #Statement written just to have a check of a program
-        
+                    Vs.append(a2)
+        # Statement written just to have a check of a program
+
         for x in self.G1.nodes():
-            neigh = (set(self.G1.nodes()) & set(list(G.neighbors(x))))						
-            #Check neighbours of sample node and if the nodes are their in sampled set then edge is included between them.				
-            for y in neigh:																
-            #Check for every node's neighbour in sample set of nodes
-                self.G1.add_edge(x, y)														
-                #Add edge between the sampled nodes
+            neigh = (set(self.G1.nodes()) & set(list(G.neighbors(x))))
+            # Check neighbours of sample node and if the nodes are their in sampled set then edge is included between them.
+            for y in neigh:
+            # Check for every node's neighbour in sample set of nodes
+                self.G1.add_edge(x, y)
+                # Add edge between the sampled nodes
         return self.G1
-        


### PR DESCRIPTION
Hi there,
this PR improves the compatibility against newer NetworkX versions.

Specifically, in `SRW_RWF_ISRW` mainly, there were outdated calls to `g.node[]` whereas newer versions of NetworkX changed to `g.nodes[]`. These calls have been fixed.

Further, code readability has been improved thanks to the Flake8 linter.

All the best